### PR TITLE
Add Chatbooks React Exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build
+devtoken

--- a/exporter.json
+++ b/exporter.json
@@ -1,25 +1,21 @@
 {
-    "id": "io.supernova.react",
-    "name": "React",
-    "description": "React token and style exporter",
-    "source_dir": "src",
-    "version": "1.2.1",
-    "tags": [
-        "React",
-        "Tokens",
-        "Styles"
-    ],
-    "author": "Ivan Terpugov & Jiri Trecak",
-    "organization": "Supernova",
-    "homepage": "https://supernova.io",
-    "usesBrands": true,
-    "config": {
-        "output": "output.json",
-        "sources": "sources.json",
-        "js": "src/js/helpers.js"
-    },
-    "engines": {
-        "pulsar": "1.0.0",
-        "supernova": "1.0.0"
-    }
+  "id": "io.supernova.react.chatbooks",
+  "name": "React - Chatbooks",
+  "description": "React token and style exporter customized for Chatbooks",
+  "source_dir": "src",
+  "version": "1.2.1",
+  "tags": ["React", "Tokens", "Styles"],
+  "author": "Ivan Terpugov & Jiri Trecak & Jason Clark",
+  "organization": "Supernova",
+  "homepage": "https://supernova.io",
+  "usesBrands": true,
+  "config": {
+    "output": "output.json",
+    "sources": "sources.json",
+    "js": "src/js/helpers.js"
+  },
+  "engines": {
+    "pulsar": "1.0.0",
+    "supernova": "1.0.0"
+  }
 }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -102,9 +102,8 @@ Pulsar.registerFunction("buildReferenceMeta", function (tokenType, tokenValue) {
   };
 });
 
-Pulsar.registerFunction("exclude", function (tokens, valueToExclude) {
+Pulsar.registerFunction("excludeOriginName", function (tokens, valueToExclude) {
   return tokens.filter(token => {
-    console.log(token.origin.name);
     return token.origin.name.toLowerCase().indexOf(valueToExclude.toLowerCase()) <= -1;
   });
 });

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -7,7 +7,7 @@ Pulsar.registerFunction(
     // Create array with all path segments and token name at the end
     const segments = [...tokenGroup.path];
     if (!tokenGroup.isRoot) {
-      segments.push(tokenGroup.name)
+      segments.push(tokenGroup.name);
     }
     segments.push(token.name);
 
@@ -19,18 +19,18 @@ Pulsar.registerFunction(
     let sentence = segments.join(" ");
 
     // Return camelcased string from all segments
-     sentence = sentence
+    sentence = sentence
       .toLowerCase()
       .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
 
     // only allow letters, digits, underscore
-    sentence = sentence.replace(/[^a-zA-Z0-9_]/g, '_')
+    sentence = sentence.replace(/[^a-zA-Z0-9_]/g, '_');
 
     // prepend underscore if it starts with digit 
     if (/^\d/.test(sentence)) {
       sentence = '_' + sentence;
     }
-    
+
     return sentence;
   }
 );
@@ -95,9 +95,16 @@ Pulsar.registerFunction("getBehavior", function (tokenType) {
   return BEHAVIOR[tokenType.toLowerCase()] || BEHAVIOR['unknown'];
 });
 
-Pulsar.registerFunction("buildReferenceMeta", function(tokenType, tokenValue){
+Pulsar.registerFunction("buildReferenceMeta", function (tokenType, tokenValue) {
   return {
     tokenType,
     referencedToken: tokenValue.referencedToken
-  }
-})
+  };
+});
+
+Pulsar.registerFunction("exclude", function (tokens, valueToExclude) {
+  return tokens.filter(token => {
+    console.log(token.origin.name);
+    return token.origin.name.toLowerCase().indexOf(valueToExclude.toLowerCase()) <= -1;
+  });
+});

--- a/src/token-renderers/rendered-css.pr
+++ b/src/token-renderers/rendered-css.pr
@@ -1,0 +1,28 @@
+{*
+
+Injectable blueprint that represents Measure token as CSS string. 
+Note that this only converts the value, actual name is provided somewhere else
+
+
+Source data: Measure Value (https://developers.supernova.io/design-system-data/tokens/measures)
+Note: Value is passed as `context` property because it is injected
+
+{
+  "context": {
+    "unit": "Pixels" | "Points" | "Percent" | "Ems",
+    "measure": double
+    "referencedToken": Measure | null
+  }
+}
+
+*}
+{[ let unit = "px" /]}
+{[ switch context.unit ]}
+  {[ case "Points"]}
+  {[ set unit = "pt"/]}
+  {[ case "Percent"]}
+  {[ set unit = "%"/]}
+  {[ case "Ems"]}
+  {[ set unit = "em"/]}
+{[/]}
+"{{ context.measure }}{{ unit }}"{[/]}

--- a/src/token-renderers/rendered-font-family.pr
+++ b/src/token-renderers/rendered-font-family.pr
@@ -1,0 +1,17 @@
+{*
+
+Injectable blueprint that renders font family names with handling for janky Circular Pro font names
+
+{
+  "context": {
+      "family": "CircularXX TT",
+      "subfamily": "Black",
+      "referencedToken": null
+    }
+}
+
+*}
+{[ if (context.family === "Inter") ]}
+"{{ context.family }}"
+{[ else ]}
+"CircularXXWeb-{{ context.subfamily }}"{[/]}

--- a/src/token-renderers/rendered-typography.pr
+++ b/src/token-renderers/rendered-typography.pr
@@ -52,9 +52,9 @@ Rendered as:
   fontFamily: "string",
   fontStyle: "string",
   fontWeight: number,
-  fontSize: Measure,
-  lineHeight: Measure,
-  letterSpacing: Measure,
+  fontSize: "string",
+  lineHeight: "string",
+  letterSpacing: "string",
   textIndent: Measure,
 }
 

--- a/src/token-renderers/rendered-typography.pr
+++ b/src/token-renderers/rendered-typography.pr
@@ -65,13 +65,16 @@ Rendered as:
   {[ if ds.isFontItalic(context.font) ]}
     {[ set fontStyle = "italic" /]}
   {[/]}
-  fontFamily: "{{ context.font.family }}",
+  fontFamily: {[ inject "rendered-font-family" context context.font /]},
   fontStyle: "{{ fontStyle }}",
   fontWeight: {{ ds.fontWeight(context.font) }},
-  fontSize: {[ inject "rendered-measure" context context.fontSize /]},
+  fontSize: {[ inject "rendered-css" context context.fontSize /]},
+  lineHeight: {[ inject "rendered-css" context context.lineHeight /]},
+  letterSpacing: {[ inject "rendered-css" context context.letterSpacing /]},
+  fontSizeM: {[ inject "rendered-measure" context context.fontSize /]},
   {[ if context.lineHeight ]}
-  lineHeight: {[ inject "rendered-measure" context context.lineHeight /]},
+  lineHeightM: {[ inject "rendered-measure" context context.lineHeight /]},
   {[/]}
-  letterSpacing: {[ inject "rendered-measure" context context.letterSpacing /]},
-  textIndent: {[ inject "rendered-measure" context context.paragraphIndent /]},
+  letterSpacingM: {[ inject "rendered-measure" context context.letterSpacing /]},
+  textIndentM: {[ inject "rendered-measure" context context.paragraphIndent /]},
 }{[/]}

--- a/src/typography.pr
+++ b/src/typography.pr
@@ -14,14 +14,14 @@ import { {{ measureBehavior.varName }} } from './{{ measureBehavior.fileName }}'
 
 {[ let brand = ds.currentBrand() /]}
 {[ const tokens = ds.tokensByType(CURRENT_TYPE, brand.id) /]}
-{[ const filteredTokens = exclude(tokens, 'mobile') /]}
+{[ const filteredTokens = excludeOriginName(tokens, 'mobile') /]}
 {[ for token in filteredTokens ]}
 {[ inject "rendered-token-var" context token /]}    
 {[/]}
 
 
 export const {{ behavior.varName }} = {
-{[ for token in tokens ]}
+{[ for token in filteredTokens ]}
   {[ inject "rendered-description" context token /]}
   {[ inject "rendered-name" context token /]},
 

--- a/src/typography.pr
+++ b/src/typography.pr
@@ -14,7 +14,8 @@ import { {{ measureBehavior.varName }} } from './{{ measureBehavior.fileName }}'
 
 {[ let brand = ds.currentBrand() /]}
 {[ const tokens = ds.tokensByType(CURRENT_TYPE, brand.id) /]}
-{[ for token in tokens ]}
+{[ const filteredTokens = exclude(tokens, 'mobile') /]}
+{[ for token in filteredTokens ]}
 {[ inject "rendered-token-var" context token /]}    
 {[/]}
 


### PR DESCRIPTION
This is really a specific use case for how we use Supernova at Chatbooks. We have our typography TypeScript Types setup to only expect string values, not measures, and due to the weird way Circular Pro font works, we have to remap the Figma font family to the actual web font name (which is admittedly janky).

The reusability of this specific exporter for other people outside of Chatbooks will be minimal, other than potentially being a reference for forking and creating your own React transformations.