### PR TITLE
PF-83: Fix having uppercased variables in the beginning when original token/group started from special characters

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -3,7 +3,7 @@
     "name": "React",
     "description": "React token and style exporter",
     "source_dir": "src",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "tags": [
         "React",
         "Tokens",

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -19,9 +19,12 @@ Pulsar.registerFunction(
     let sentence = segments.join(" ");
 
     // Return camelcased string from all segments
-     sentence = sentence
+    sentence = sentence
       .toLowerCase()
-      .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+      .replace(/[^a-zA-Z0-9_]+(.)/g, (m, chr) => chr.toUpperCase());
+
+    // if string was started with special character that was cut then turn first char to lowercase
+    sentence = sentence.charAt(0).toLowerCase() + sentence.slice(1);
 
     // only allow letters, digits, underscore
     sentence = sentence.replace(/[^a-zA-Z0-9_]/g, '_')
@@ -79,12 +82,12 @@ const BEHAVIOR = {
   },
   radius: {
     fileName: "radii", // this should be somehow synced with output.json contents
-    varName: "Raddii",
+    varName: "Radii",
     themeProperty: "radii",
     tokenPrefix: "",
   },
   unknown: {
-    fileName: "uknown",
+    fileName: "unknown",
     varName: "Unknowns",
     themeProperty: "unknowns",
     tokenPrefix: "",

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -82,12 +82,12 @@ const BEHAVIOR = {
   },
   radius: {
     fileName: "radii", // this should be somehow synced with output.json contents
-    varName: "Radii",
+    varName: "Raddii",
     themeProperty: "radii",
     tokenPrefix: "",
   },
   unknown: {
-    fileName: "unknown",
+    fileName: "uknown",
     varName: "Unknowns",
     themeProperty: "unknowns",
     tokenPrefix: "",


### PR DESCRIPTION
Previously, when token or group started with special character then variable will be capitalized.

<img width="1331" alt="image" src="https://github.com/Supernova-Studio/exporter-react/assets/9402858/80ab2a91-3a87-4e1a-befc-683d16bd8179">

Additionally, typos in generated variable names were fixed: `Raddii` -> `Radii`, `uknown` -> `unknown`.
